### PR TITLE
Add drupal/core as a dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "php": ">=7.0.0",
         "phpunit/phpunit": "~5.7",
         "behat/mink": "^1.7",
-        "behat/mink-goutte-driver": "^1.2"
+        "behat/mink-goutte-driver": "^1.2",
+        "drupal/core": "^8",
     },
     "autoload": {
         "psr-4": { "weitzman\\DrupalTestTraits\\": "src" }


### PR DESCRIPTION
I'm not sure which D8 min version we want to support.