### PR TITLE
Allow using the traits with PHPUnit 6.5.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "phpunit/phpunit": "~5.7",
+        "phpunit/phpunit": "^5.7|^6.5",
         "behat/mink": "^1.7",
         "behat/mink-goutte-driver": "^1.2",
         "webflo/drupal-finder": "^1.1"


### PR DESCRIPTION
The current allowed version of PHPUnit with PHP 7 in the core is `^6.5`. We should allow using that.