### PR TITLE
Provide a way to automatically cleanup nodes created during tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,11 @@ traits have a @before annotation, Drupal and Mink are automatically setup.
 
 ## Running Tests
 
-You must specify the URL to your site as an environment variable: `DTT_BASE_URL=http://example.com`. Here are two ways to do that:
-
-- Enter that line into a .env file. These files are supported by [drupal-project](https://github.com/drupal-composer/drupal-project/blob/8.x/.env.example) and [Docker](https://docs.docker.com/compose/env-file/). 
-- Specify an environment variable at runtime: `DTT_BASE_URL=http://127.0.0.1:8888 vendor/bin/phpunit ...`
-
-Depending on your setup, you may wish to run phpunit as the web server user `su -s /bin/bash www-data -c "vendor/bin/phpunit ..."`
+- You must specify the URL to your site as an environment variable: `DTT_BASE_URL=http://example.com`. Here are two ways to do that:
+    - Enter that line into a .env file. These files are supported by [drupal-project](https://github.com/drupal-composer/drupal-project/blob/8.x/.env.example) and [Docker](https://docs.docker.com/compose/env-file/). 
+    - Specify an environment variable at runtime: `DTT_BASE_URL=http://127.0.0.1:8888 vendor/bin/phpunit ...`
+- If you use NodeTrait, add --bootstrap like so: `--bootstrap=web/core/tests/bootstrap.php ` (points at Drupal core) 
+- Depending on your setup, you may wish to run phpunit as the web server user `su -s /bin/bash www-data -c "vendor/bin/phpunit ..."`
 
 ## Available traits
 

--- a/src/Entity/NodeCreationTrait.php
+++ b/src/Entity/NodeCreationTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace weitzman\DrupalTestTraits\Entity;
+
+use Drupal\Tests\node\Traits\NodeCreationTrait as CoreNodeCreationTrait;
+use Drupal\Tests\RandomGeneratorTrait;
+
+/**
+ * Wraps the node creation trait to track entities for deletion.
+ */
+trait NodeCreationTrait
+{
+
+  use CoreNodeCreationTrait {
+    createNode as coreCreateNode;
+  }
+  use RandomGeneratorTrait;
+
+  /**
+   * Creates a node and marks it for automatic cleanup.
+   *
+   * @param array $settings
+   * @return \Drupal\node\NodeInterface
+   */
+  protected function createNode(array $settings = [])
+  {
+    $entity = $this->coreCreateNode($settings);
+    $this->markEntityForCleanup($entity);
+    return $entity;
+  }
+
+}

--- a/tests/Entity/NodeCreationTraitTest.php
+++ b/tests/Entity/NodeCreationTraitTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace weitzman\DrupalTestTraits\Tests\Entity;
+
+use PHPUnit\Framework\TestCase;
+use weitzman\DrupalTestTraits\DrupalSetup;
+use weitzman\DrupalTestTraits\Entity\NodeCreationTrait;
+
+/**
+ * Test the node creation trait.
+ */
+class NodeCreationTraitTest extends TestCase
+{
+  use DrupalSetup;
+  use NodeCreationTrait;
+
+  public function testAutoCleanup()
+  {
+    $node = $this->createNode(['type' => 'article']);
+    $this->assertCount(1, $this->cleanupEntities);
+    $this->assertEquals($node->id(), $this->cleanupEntities[0]->id());
+  }
+}

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -7,6 +7,7 @@ use Drupal\file\Entity\File;
 use Drupal\node\Entity\Node;
 use PHPUnit\Framework\TestCase;
 use weitzman\DrupalTestTraits\DrupalSetup;
+use weitzman\DrupalTestTraits\Entity\NodeCreationTrait;
 use weitzman\DrupalTestTraits\MinkSetup;
 
 /**
@@ -19,6 +20,7 @@ class ExampleTest extends TestCase {
    */
   use MinkSetup;
   use DrupalSetup;
+  use NodeCreationTrait;
 
   /**
    * An example test method; note that Drupal API's and Mink are available.
@@ -33,8 +35,8 @@ class ExampleTest extends TestCase {
     $src = 'core/tests/Drupal/Tests/Component/FileCache/Fixtures/llama-23.txt';
     file_unmanaged_copy($src, $destination, TRUE);
 
-    // Create a "Llama" article.
-    $node = Node::create([
+    // Create a "Llama" article. Will be automatically cleaned up at end of test.
+    $node = $this->createNode([
       'title' => 'Llama',
       'type' => 'article',
       'field_image' => [
@@ -42,7 +44,6 @@ class ExampleTest extends TestCase {
       ],
     ]);
     $node->setPublished(TRUE)->save();
-    $this->markEntityForCleanup($node);
 
     $url = $file->url();
     $this->visit($url);


### PR DESCRIPTION
This wraps the matching Drupal core testing feature.