### PR TITLE
Fix #8. Do not use @before and @after annotations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     working_directory: /var/www/code
     docker:
       # @see https://github.com/massgov/Drupal-Container
-      - image: massgov/drupal-container:1.0.2-ci
+      - image: massgov/drupal-container:1.0.6-ci
         environment:
           COMPOSER_ALLOW_SUPERUSER: 1
           DTT_BASE_URL: http://127.0.0.1

--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ product quality and not conversations, this is a testing approach for you.
 
 See [ExampleTest.php](./tests/ExampleTest.php)
 
-Add a `use` statement for the desired trait to your PHPUnit test class. Since our
-traits have a @before annotation, Drupal and Mink are automatically setup. 
-
-## Running Tests
+In addition to a case like above you will want a base TestCase class which is
+then extended by all the tests in your project. [ExampleBase.php](src/ExampleBase.php) serves as a model 
+that you can copy.
+  
+## Running your tests
 
 - You must specify the URL to your site as an environment variable: `DTT_BASE_URL=http://example.com`. Here are two ways to do that:
     - Enter that line into a .env file. These files are supported by [drupal-project](https://github.com/drupal-composer/drupal-project/blob/8.x/.env.example) and [Docker](https://docs.docker.com/compose/env-file/). 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ product quality and not conversations, this is a testing approach for you.
 
 See [ExampleTest.php](./tests/ExampleTest.php)
 
-In addition to a case like above you will want a base TestCase class which is
-then extended by all the tests in your project. [ExampleBase.php](src/ExampleBase.php) serves as a model 
-that you can copy.
+In addition to a test like above, you must create or edit a base TestCase class 
+which is then extended by all the tests in your project. [ExampleBase.php](src/ExampleBase.php) 
+serves as a model that you can copy.
   
 ## Running your tests
 

--- a/src/DrupalSetup.php
+++ b/src/DrupalSetup.php
@@ -17,11 +17,7 @@ trait DrupalSetup
   protected $cleanupEntities = [];
 
   /**
-   * Bootstrap Drupal.
-   *
-   * Due to the annotation below, this method runs automatically when the trait is `use`d.
-   *
-   * @before
+   * Bootstrap Drupal. Call this from your setUp() method.
    */
   public function setupDrupal()
   {
@@ -45,7 +41,7 @@ trait DrupalSetup
   }
 
   /**
-   * @after
+   * Delete marked entities. Call this from your case's tearDown() method.
    *
    * @throws \Drupal\Core\Entity\EntityStorageException
    */

--- a/src/ExampleBase.php
+++ b/src/ExampleBase.php
@@ -6,8 +6,7 @@ use PHPUnit\Framework\TestCase;
 use weitzman\DrupalTestTraits\Entity\NodeCreationTrait;
 
 /**
- * You are encouraged to copy the methods here into your own base class. All your
- * tests then extend it.
+ * You are encouraged to copy the methods here into your own base class.
  */
 abstract class ExampleBase extends TestCase {
 

--- a/src/ExampleBase.php
+++ b/src/ExampleBase.php
@@ -6,7 +6,8 @@ use PHPUnit\Framework\TestCase;
 use weitzman\DrupalTestTraits\Entity\NodeCreationTrait;
 
 /**
- * You are encouraged to copy the methods here into your own base class.
+ * You are encouraged to copy the methods here into your own base class. Or if
+ * you are lazy like me, you can extend it directly.
  */
 abstract class ExampleBase extends TestCase {
 

--- a/src/ExampleBase.php
+++ b/src/ExampleBase.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace weitzman\DrupalTestTraits;
+
+use PHPUnit\Framework\TestCase;
+use weitzman\DrupalTestTraits\Entity\NodeCreationTrait;
+
+/**
+ * You are encouraged to copy the methods here into your own base class. All your
+ * tests then extend it.
+ */
+class ExampleBase extends TestCase {
+
+  use DrupalSetup;
+  use MinkSetup;
+  use NodeCreationTrait;
+
+  public function setUp() {
+    parent::setUp();
+    $this->setupDrupal();
+    $this->setupMinkSession();
+  }
+
+  public function tearDown() {
+    parent::tearDown();
+    $this->tearDownDrupal();
+    $this->tearDownMinkSession();
+  }
+}

--- a/src/ExampleBase.php
+++ b/src/ExampleBase.php
@@ -9,7 +9,7 @@ use weitzman\DrupalTestTraits\Entity\NodeCreationTrait;
  * You are encouraged to copy the methods here into your own base class. All your
  * tests then extend it.
  */
-class ExampleBase extends TestCase {
+abstract class ExampleBase extends TestCase {
 
   use DrupalSetup;
   use MinkSetup;

--- a/src/MinkSetup.php
+++ b/src/MinkSetup.php
@@ -13,9 +13,8 @@ trait MinkSetup
 
   /**
    *
-   * Due to the annotation below, this method runs automatically when the trait is `use`d.
+   * Setup a Mink session. Call this from your setUp() method.
    *
-   * @before
    */
   public function setupMinkSession()
   {
@@ -33,9 +32,7 @@ trait MinkSetup
   }
 
   /**
-   * Stop session.
-   *
-   * @after
+   * Stop session. Call this from your tearDown() method.
    */
   public function tearDownMinkSession() {
     $this->getSession()->stop();

--- a/tests/Entity/NodeCreationTraitTest.php
+++ b/tests/Entity/NodeCreationTraitTest.php
@@ -2,20 +2,13 @@
 
 namespace weitzman\DrupalTestTraits\Tests\Entity;
 
-use PHPUnit\Framework\TestCase;
-use weitzman\DrupalTestTraits\DrupalSetup;
-use weitzman\DrupalTestTraits\Entity\NodeCreationTrait;
+use weitzman\DrupalTestTraits\ExampleBase;
 
 /**
  * Test the node creation trait.
  */
-class NodeCreationTraitTest extends TestCase
-{
-  use DrupalSetup;
-  use NodeCreationTrait;
-
-  public function testAutoCleanup()
-  {
+class NodeCreationTraitTest extends ExampleBase {
+  public function testAutoCleanup() {
     $node = $this->createNode(['type' => 'article']);
     $this->assertCount(1, $this->cleanupEntities);
     $this->assertEquals($node->id(), $this->cleanupEntities[0]->id());

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -7,19 +7,15 @@ use Drupal\file\Entity\File;
 use PHPUnit\Framework\TestCase;
 use weitzman\DrupalTestTraits\DrupalSetup;
 use weitzman\DrupalTestTraits\Entity\NodeCreationTrait;
+use weitzman\DrupalTestTraits\ExampleBase;
 use weitzman\DrupalTestTraits\MinkSetup;
 
 /**
- * A model test class using 2 traits from Drupal Test Traits.
+ * A model test case using traits from Drupal Test Traits.
+ *
+ * The code in ExampleBase.php should be incorporated into your own test base class.
  */
-class ExampleTest extends TestCase {
-
-  /**
-   * Make Mink and Drupal available to this class.
-   */
-  use MinkSetup;
-  use DrupalSetup;
-  use NodeCreationTrait;
+class ExampleTest extends ExampleBase {
 
   /**
    * An example test method; note that Drupal API's and Mink are available.


### PR DESCRIPTION
Per #8, require users to call setUp() and tearDown() for our traits. Its a bit more work,but less surprising.