### PR TITLE
Fix session name generation.

### DIFF
--- a/src/MinkSetup.php
+++ b/src/MinkSetup.php
@@ -38,8 +38,7 @@ trait MinkSetup
     // document matches the domain.
     // @see https://w3c.github.io/webdriver/webdriver-spec.html#add-cookie
     // @see https://www.w3.org/Bugs/Public/show_bug.cgi?id=20975
-    $session = $this->getSession();
-    $session->visit($this->minkBaseUrl);
+    $this->minkSession->visit($this->minkBaseUrl);
   }
 
   /**

--- a/src/MinkSetup.php
+++ b/src/MinkSetup.php
@@ -29,6 +29,17 @@ trait MinkSetup
     if ($output_dir && !is_dir($output_dir)) {
       mkdir($output_dir, 0777, TRUE);
     }
+
+    // According to the W3C WebDriver specification a cookie can only be set if
+    // the cookie domain is equal to the domain of the active document. When the
+    // browser starts up the active document is not our domain but 'about:blank'
+    // or similar. To be able to set our User-Agent and Xdebug cookies at the
+    // start of the test we now do a request to the front page so the active
+    // document matches the domain.
+    // @see https://w3c.github.io/webdriver/webdriver-spec.html#add-cookie
+    // @see https://www.w3.org/Bugs/Public/show_bug.cgi?id=20975
+    $session = $this->getSession();
+    $session->visit($this->minkBaseUrl);
   }
 
   /**

--- a/src/MinkSetup.php
+++ b/src/MinkSetup.php
@@ -38,7 +38,7 @@ trait MinkSetup
     // document matches the domain.
     // @see https://w3c.github.io/webdriver/webdriver-spec.html#add-cookie
     // @see https://www.w3.org/Bugs/Public/show_bug.cgi?id=20975
-    $this->minkSession->visit($this->minkBaseUrl);
+    $this->minkSession->visit($this->minkBaseUrl . '/core/misc/druplicon.png');
   }
 
   /**


### PR DESCRIPTION
This fix is pulled directly from BTB, without it we are unable to successfully login within tests.