### PR TITLE
Fix additional memory leaks in DrupalSetup and MinkSetup

### DIFF
--- a/src/DrupalSetup.php
+++ b/src/DrupalSetup.php
@@ -65,10 +65,12 @@ trait DrupalSetup
     foreach ($this->cleanupEntities as $entity) {
         $entity->delete();
     }
-    // Remove references to deleted entities and shut down Kernel so we don't leak memory.
+    // Avoid leaking memory in test cases (which are retained for a long time)
+    // by removing references to all the things.
     $this->cleanupEntities = [];
     $this->kernel->shutdown();
     $this->kernel = NULL;
+    $this->container = NULL;
   }
 
   /**

--- a/src/MinkSetup.php
+++ b/src/MinkSetup.php
@@ -46,6 +46,9 @@ trait MinkSetup
    */
   public function tearDownMinkSession() {
     $this->getSession()->stop();
+    // Avoid leaking memory in test cases (which are retained for a long time)
+    // by removing references to all the things.
+    $this->minkSession = NULL;
   }
 
   public function getSession() {


### PR DESCRIPTION
These are the last ones, I hope.  It seems that test instances are retained for the duration of testing unless we use process isolation (which is slow, and should be unnecessary).  So it's vital that all references are zeroed out when tearDown is called to avoid memory issues.