### PR TITLE
JUnit output from our own tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
       - run: vendor/bin/parallel-lint src tests
       - run: vendor/bin/phpcs --report-full
       - run: vendor/bin/drush si -yv --db-url=mysql://circle:circle@127.0.0.1/circle standard
+      - run: mkdir -p /tmp/test-results/phpunit
       - run: vendor/bin/phpunit --bootstrap=web/core/tests/bootstrap.php --log-junit /tmp/test-results/phpunit tests
       - store_test_results:
             path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,8 @@ jobs:
       - run: vendor/bin/parallel-lint src tests
       - run: vendor/bin/phpcs --report-full
       - run: vendor/bin/drush si -yv --db-url=mysql://circle:circle@127.0.0.1/circle standard
+      # Wait for web server
+      - run: dockerize -wait tcp://127.0.0.1:80 -timeout 2m
       - run: vendor/bin/phpunit --bootstrap=web/core/tests/bootstrap.php --log-junit /tmp/test-results/phpunit tests
       - store_test_results:
             path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,6 @@ jobs:
       - run: vendor/bin/phpcs --report-full
       - run: vendor/bin/drush si -yv --db-url=mysql://circle:circle@127.0.0.1/circle standard
       - run: mkdir -p /tmp/test-results/phpunit
-      - run: vendor/bin/phpunit --bootstrap=web/core/tests/bootstrap.php --log-junit /tmp/test-results/phpunit tests
+      - run: vendor/bin/phpunit --colors --bootstrap=web/core/tests/bootstrap.php --log-junit /tmp/test-results/phpunit/results.xml tests
       - store_test_results:
             path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,10 @@ jobs:
         command: --max_allowed_packet=32M --innodb_flush_method=O_DIRECT --tmp_table_size=16M --query_cache_size=16M --innodb-flush-log-at-trx-commit=2  --innodb_buffer_pool_size=500M --innodb_log_buffer_size=64M --skip-innodb_doublewrite --innodb_log_file_size=64M
     steps:
       - checkout
-      - run: echo 'export PATH=/var/www/code/vendor/bin:$PATH' >> $BASH_ENV
       - run: composer install -n --prefer-dist
       - run: vendor/bin/parallel-lint src tests
       - run: vendor/bin/phpcs --report-full
-      - run: {name: 'Start Apache', command: '/usr/local/bin/apache2-foreground-enhanced', background: true}
       - run: drush si -yv --db-url=mysql://circle:circle@127.0.0.1/circle standard
-      - run: phpunit --bootstrap=web/core/tests/bootstrap.php tests
+      - run: phpunit --bootstrap=web/core/tests/bootstrap.php --log-junit /tmp/test-results/phpunit tests
+      - store_test_results:
+            path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run: composer install -n --prefer-dist
       - run: vendor/bin/parallel-lint src tests
       - run: vendor/bin/phpcs --report-full
-      - run: drush si -yv --db-url=mysql://circle:circle@127.0.0.1/circle standard
-      - run: phpunit --bootstrap=web/core/tests/bootstrap.php --log-junit /tmp/test-results/phpunit tests
+      - run: vendor/bin/drush si -yv --db-url=mysql://circle:circle@127.0.0.1/circle standard
+      - run: vendor/bin/phpunit --bootstrap=web/core/tests/bootstrap.php --log-junit /tmp/test-results/phpunit tests
       - store_test_results:
             path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           COMPOSER_ALLOW_SUPERUSER: 1
           DTT_BASE_URL: http://127.0.0.1
           APACHE_DOCROOT: /var/www/code/web
-      - image: mariadb
+      - image: mariadb:10.3.6
         environment:
           MYSQL_USER: circle
           MYSQL_PASSWORD: circle
@@ -19,12 +19,11 @@ jobs:
         command: --max_allowed_packet=32M --innodb_flush_method=O_DIRECT --tmp_table_size=16M --query_cache_size=16M --innodb-flush-log-at-trx-commit=2  --innodb_buffer_pool_size=500M --innodb_log_buffer_size=64M --skip-innodb_doublewrite --innodb_log_file_size=64M
     steps:
       - checkout
+      - run: {name: 'Start Apache', command: '/usr/local/bin/apache2-foreground-enhanced', background: true}
       - run: composer install -n --prefer-dist
       - run: vendor/bin/parallel-lint src tests
       - run: vendor/bin/phpcs --report-full
       - run: vendor/bin/drush si -yv --db-url=mysql://circle:circle@127.0.0.1/circle standard
-      # Wait for web server
-      - run: dockerize -wait tcp://127.0.0.1:80 -timeout 2m
       - run: vendor/bin/phpunit --bootstrap=web/core/tests/bootstrap.php --log-junit /tmp/test-results/phpunit tests
       - store_test_results:
             path: /tmp/test-results

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,3 +33,8 @@ services:
     command: --max_allowed_packet=32M --innodb_flush_method=O_DIRECT --tmp_table_size=16M --query_cache_size=16M --innodb-flush-log-at-trx-commit=2  --innodb_buffer_pool_size=500M --innodb_log_buffer_size=64M --skip-innodb_doublewrite --innodb_log_file_size=64M
     ports:
       - '3106:3306'
+    volumes:
+      - dtt-datavolume:/var/lib/mysql
+#data volumes https://docs.docker.com/storage/volumes/
+volumes:
+  dtt-datavolume:


### PR DESCRIPTION
And use a datavolume for persistent mysql data when using our docker-compose